### PR TITLE
消費者登入邏輯改正

### DIFF
--- a/accounts/adaptor.py
+++ b/accounts/adaptor.py
@@ -10,82 +10,85 @@ from customers_account.models import Customer
 
 logger = logging.getLogger(__name__)
 
-GOOGLE_PROVIDER = 'google'
-CUSTOMER_TYPE = 'customer'
+GOOGLE_PROVIDER = "google"
+CUSTOMER_TYPE = "customer"
 
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
-    
+
     def _get_email_from_sociallogin(self, sociallogin):
         """從社群登入資料中取得並驗證 email"""
-        try:    
+        try:
             extra_data = sociallogin.account.extra_data
-                
-            email = extra_data.get('email')
+
+            email = extra_data.get("email")
             if not email or not isinstance(email, str):
                 return None
-                
+
             # 驗證 email 格式
             email = email.strip().lower()
             validator = EmailValidator()
             validator(email)
-            
+
             return email
-            
+
         except (EmailValidationError, AttributeError, TypeError):
             return None
-    
+
     def _get_name_from_sociallogin(self, sociallogin):
         """從社群登入資料中取得姓名"""
-        try:  
+        try:
             extra_data = sociallogin.account.extra_data
-                
-            name = extra_data.get('name', '')
+
+            name = extra_data.get("name", "")
             if not name or not isinstance(name, str):
-                return ''
-                
+                return ""
+
             return name.strip()
-            
+
         except (AttributeError, TypeError):
-            return ''
-    
+            return ""
+
     def _find_customer_with_social_info(self, email):
         """一次查詢取得消費者帳號及其 Google 社群帳號連結狀況"""
         try:
-            member = Member.objects.prefetch_related('socialaccount_set').filter(
-                email=email,
-                member_type=CUSTOMER_TYPE
-            ).first()
-            
+            member = (
+                Member.objects.prefetch_related("socialaccount_set")
+                .filter(email=email, member_type=CUSTOMER_TYPE)
+                .first()
+            )
+
             if not member:
                 return None, False
-                
+
             # 檢查是否已有 Google 連結
             has_google_account = any(
-                social.provider == GOOGLE_PROVIDER 
+                social.provider == GOOGLE_PROVIDER
                 for social in member.socialaccount_set.all()
             )
-            
+
             return member, has_google_account
-            
+
         except Exception:
             return None, False
-    
+
     def pre_social_login(self, request, sociallogin):
         """
         在社群登入之前檢查是否有相同 email 的用戶。如果有，就連結現有帳號；如果沒有，允許創建新帳號
         """
-        
+
         if sociallogin.is_existing:
             return
-        
+
         email = self._get_email_from_sociallogin(sociallogin)
         if not email:
             return
-        
+
         # 查詢消費者帳號及 Google 連結狀況
-        existing_customer, has_google_account = self._find_customer_with_social_info(email)
-        
+        existing_customer, has_google_account = self._find_customer_with_social_info(
+            email
+        )
+
         if existing_customer and not has_google_account:
             # 還沒有 Google 連結，連結現有用戶
             try:
@@ -101,9 +104,9 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
             except Exception as e:
                 logger.error(f"帳號連結失敗 - 未知錯誤: {e}, email: {email}")
                 raise ValidationError("系統異常，請稍後再試或聯繫客服")
-            
+
         return super().pre_social_login(request, sociallogin)
-    
+
     def save_user(self, request, sociallogin, form=None):
         """
         當創建新的社群登入用戶時，同時創建對應的 Customer 記錄
@@ -111,35 +114,34 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
         email = self._get_email_from_sociallogin(sociallogin)
         if not email:
             raise ValidationError("無法從 Google 帳號取得有效的 email 地址")
-            
+
         name = self._get_name_from_sociallogin(sociallogin)
-        
+
         try:
             with transaction.atomic():
                 # 創建 Member
                 user = super().save_user(request, sociallogin, form)
-                
+
                 if not user or not user.pk:
                     raise ValidationError("用戶創建失敗")
-                
+
                 user.member_type = CUSTOMER_TYPE
-                user.save(update_fields=['member_type'])
-                
+                user.save(update_fields=["member_type"])
+
                 try:
                     customer, created = Customer.objects.get_or_create(
                         member=user,
                         defaults={
-                            'email': user.email,
-                            'name': name,
-                        }
+                            "name": name,
+                        },
                     )
                 except IntegrityError:
                     customer = Customer.objects.filter(member=user).first()
                     if not customer:
                         raise ValidationError("Customer 記錄創建失敗")
-                
+
                 return user
-                
+
         except ValidationError:
             raise
         except IntegrityError as e:


### PR DESCRIPTION
如果今天消費者透過google第三方登入後，如果嘗試要用相同的電子郵件去用網站註冊跟登入會做阻擋請他用google登入。



<img width="890" height="644" alt="截圖 2025-09-05 下午4 20 58" src="https://github.com/user-attachments/assets/532fda57-3d43-4723-8fe8-3d699b5076fc" />

<img width="705" height="692" alt="截圖 2025-09-05 下午4 21 20" src="https://github.com/user-attachments/assets/6dbc4bc3-b5cc-4458-b7e4-add6c6b25e53" />
