### PR TITLE
fixed:user/商家總支出/收入加總修正 只計算paid #124

### DIFF
--- a/customers_account/views.py
+++ b/customers_account/views.py
@@ -122,7 +122,9 @@ def dashboard(request):
 
     # 統計資料
     total_orders = orders.count()
-    total_amount = sum(order.amount for order in orders)
+    # 只計算已付款訂單的金額
+    paid_orders = orders.filter(status="paid")
+    total_amount = sum(order.amount for order in paid_orders)
     pending_orders = orders.filter(status="pending").count()
 
     # 最近5筆購買記錄

--- a/merchant_account/views.py
+++ b/merchant_account/views.py
@@ -96,8 +96,9 @@ def dashboard(request, subdomain):
         "-created_at"
     )[:5]
 
-    # 計算總收入
-    total_revenue = orders.aggregate(total=Sum("amount"))["total"] or 0
+    # 計算總收入（只計算已付款的訂單）
+    paid_orders = orders.filter(status="paid")
+    total_revenue = paid_orders.aggregate(total=Sum("amount"))["total"] or 0
 
     context = {
         "merchant": request.merchant,


### PR DESCRIPTION
商家總收入已修復 只計算已付款部分

<img width="1405" height="327" alt="截圖 2025-09-05 17 18 21" src="https://github.com/user-attachments/assets/28d438c5-c621-45a0-a78d-1be7d665591e" />

user總消費金額已修復 只計算已付款部分

<img width="1389" height="566" alt="截圖 2025-09-05 17 18 48" src="https://github.com/user-attachments/assets/a1aff7ef-54b7-46f6-90f9-bdd4d3661bdb" />
