### PR TITLE
fix:修改商家交易記錄的超連結到自己的票券使用記錄，挑整篩選按鈕的css

### DIFF
--- a/merchant_account/templates/merchant_account/verification_records.html
+++ b/merchant_account/templates/merchant_account/verification_records.html
@@ -62,10 +62,10 @@
 
     <!-- 篩選功能 -->
     <div class="bg-white p-6 rounded-lg shadow-sm border border-gray-200 mb-8">
-        <form method="GET" class="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div>
+        <form method="GET" class="flex gap-4 items-end">
+            <div class="flex-1">
                 <label for="product" class="block text-sm font-medium text-gray-700 mb-2">商品</label>
-                <select name="product" id="product" class="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                <select name="product" id="product" class="w-full px-2 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-left">
                     <option value="">全部商品</option>
                     {% for product in products %}
                         <option value="{{ product.id }}" {% if product_filter|stringformat:'s' == product.id|stringformat:'s' %}selected{% endif %}>{{ product.name }}</option>
@@ -73,22 +73,28 @@
                 </select>
             </div>
             
-            <div>
+            <div class="flex-1">
                 <label for="customer" class="block text-sm font-medium text-gray-700 mb-2">客戶 Email</label>
                 <input type="text" name="customer" id="customer" value="{{ customer_filter }}" placeholder="搜尋客戶 email"
                        class="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
             
-            <div>
+            <div class="flex-1">
                 <label for="date" class="block text-sm font-medium text-gray-700 mb-2">使用日期</label>
                 <input type="date" name="date" id="date" value="{{ date_filter }}" 
                        class="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
             </div>
             
-            <div class="flex items-end">
-                <button type="submit" class="w-full bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition duration-200">
+            <div class="flex-1">
+                <label for="order" class="block text-sm font-medium text-gray-700 mb-2">訂單編號</label>
+                <input type="text" name="order" id="order" value="{{ order_filter }}" placeholder="搜尋訂單編號"
+                       class="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+            </div>
+            
+            <div class="flex-none">
+                <button type="submit" class="inline-flex items-center gap-2 bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition duration-200 whitespace-nowrap">
                     {% include 'components/icons.html' with icon='filter' %}
-                    篩選
+                    <span>篩選</span>
                 </button>
             </div>
         </form>
@@ -163,7 +169,7 @@
                         </div>
                         <div class="flex space-x-2">
                             {% if page_obj.has_previous %}
-                                <a href="?{% if product_filter %}product={{ product_filter }}&{% endif %}{% if customer_filter %}customer={{ customer_filter }}&{% endif %}{% if date_filter %}date={{ date_filter }}&{% endif %}page={{ page_obj.previous_page_number }}" 
+                                <a href="?{% if product_filter %}product={{ product_filter }}&{% endif %}{% if customer_filter %}customer={{ customer_filter }}&{% endif %}{% if date_filter %}date={{ date_filter }}&{% endif %}{% if order_filter %}order={{ order_filter }}&{% endif %}page={{ page_obj.previous_page_number }}" 
                                    class="px-3 py-2 text-sm text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
                                     上一頁
                                 </a>
@@ -174,7 +180,7 @@
                             </span>
                             
                             {% if page_obj.has_next %}
-                                <a href="?{% if product_filter %}product={{ product_filter }}&{% endif %}{% if customer_filter %}customer={{ customer_filter }}&{% endif %}{% if date_filter %}date={{ date_filter }}&{% endif %}page={{ page_obj.next_page_number }}" 
+                                <a href="?{% if product_filter %}product={{ product_filter }}&{% endif %}{% if customer_filter %}customer={{ customer_filter }}&{% endif %}{% if date_filter %}date={{ date_filter }}&{% endif %}{% if order_filter %}order={{ order_filter }}&{% endif %}page={{ page_obj.next_page_number }}" 
                                    class="px-3 py-2 text-sm text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
                                     下一頁
                                 </a>

--- a/public_store/templates/public_store/payment_page.html
+++ b/public_store/templates/public_store/payment_page.html
@@ -1,4 +1,4 @@
-{% extends "layouts/default.html" %}
+ {% extends "layouts/default.html" %}
 {% block content %}
 <div class="container mx-auto px-4 py-8">
     <div class="max-w-6xl mx-auto">
@@ -28,18 +28,14 @@
                 </div>
                 
                 <!-- 商品資訊 -->
-                <div class="md:w-1/2 p-8" x-data="{ 
-                    ...createQuantityManager(),
-                    needsVerification: '{{ product.verification_timing }}' === 'before_payment',
-                    isVerified: false,
-                    termsAgreed: false,
-                    verificationData: {
-                        terms: false,
-                        identity: '',
-                        phone: ''
-                    }
-                }" 
-                     data-unit-price="{{ product.price }}" data-max-stock="{{ product.stock }}">
+                <div class="md:w-1/2 p-8" x-data="createQuantityManager()" 
+                     data-unit-price="{{ product.price }}" data-max-stock="{{ product.stock }}"
+                     x-init="
+                         needsVerification = '{{ product.verification_timing }}' === 'before_payment';
+                         isVerified = false;
+                         termsAgreed = false;
+                         verificationData = { terms: false, identity: '', phone: '' };
+                     ">
                     <div class="mb-6">
                         <h1 class="text-3xl font-bold text-gray-800 mb-4">{{ product.name }}</h1>
                         <p class="text-4xl font-bold text-[#0056B3] mb-6">NT$ {{ product.price }}</p>

--- a/templates/shared/order_table.html
+++ b/templates/shared/order_table.html
@@ -50,10 +50,17 @@
             {% for item in order_items %}
             <tr>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                    <a href="{% url 'customers_account:ticket_wallet' %}?order={{ item.provider_order_id }}" 
-                       class="font-medium text-blue-600 underline hover:text-blue-700 transition-colors">
-                        {{ item.provider_order_id }}
-                    </a>
+                    {% if role == 'merchant' %}
+                        <a href="{% url 'merchant_account:verification_records' request.merchant.subdomain %}?order={{ item.provider_order_id }}" 
+                           class="font-medium text-blue-600 underline hover:text-blue-700 transition-colors">
+                            {{ item.provider_order_id }}
+                        </a>
+                    {% else %}
+                        <a href="{% url 'customers_account:ticket_wallet' %}?order={{ item.provider_order_id }}" 
+                           class="font-medium text-blue-600 underline hover:text-blue-700 transition-colors">
+                            {{ item.provider_order_id }}
+                        </a>
+                    {% endif %}
                 </td>
                 {% if role == 'merchant' %}
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">


### PR DESCRIPTION
### 商家交易記錄按鈕按下去後會導到票券使用記錄，會在訂單編號搜尋欄位直接帶入訂單編號做搜尋
<img width="1296" height="176" alt="image" src="https://github.com/user-attachments/assets/f0e1dfd2-ba0d-4db1-8aa1-2a065e0c687e" />
